### PR TITLE
Change "Under Construction" watermark

### DIFF
--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -3,7 +3,7 @@ html {
 }
 
 body:before{
-    content: 'UNDER CONSTRUCTION - DO NOT USE';
+    content: 'UNDER CONSTRUCTION - INCOMPLETE AND UNVERIFIED';
     position: fixed;
     top: 0;
     bottom: 0;

--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -3,7 +3,7 @@ html {
 }
 
 body:before{
-    content: 'UNDER CONSTRUCTION - INCOMPLETE AND UNVERIFIED';
+    content: 'UNDER CONSTRUCTION';
     position: fixed;
     top: 0;
     bottom: 0;


### PR DESCRIPTION
Change "UNDER CONSTRUCTION - DO NOT USE" to "UNDER CONSTRUCTION"

In my opinion "do not use" is to restrictive and lets (new) user ignoe the site. So they do not even report errors / missing info or even contribute content. I think that a warning that the info is incomplete is OK and sufficient.

Please discuss in docu group and accept or cancel PR.